### PR TITLE
Add visit option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.idea
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+=== Version 0.11
+* Added optional 'visit' argument to navigate_to and navigate_all to visit first page
+
 === Version 0.10
 * Improved error message when navigation methods are undefined
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'rake'
 gem 'rb-fsevent', :require => false if RUBY_PLATFORM =~ /darwin/i

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'http://rubygems.org'
 
 gem 'rake'
 gem 'rb-fsevent', :require => false if RUBY_PLATFORM =~ /darwin/i

--- a/lib/page_navigation.rb
+++ b/lib/page_navigation.rb
@@ -127,12 +127,8 @@ module PageNavigation
   
   def navigate_through_pages(pages, visit)
     pages.each do |cls, method, *args|
-      if visit
-        page = visit(cls)
-        visit = false # visit once, for just the first page
-      else
-        page = on(cls)
-      end
+      page = visit ? visit(cls) : on(cls)
+      visit = false # visit once, for just the first page
       fail("Navigation method '#{method}' not defined on #{cls}.") unless page.respond_to? method
       page.send method unless args
       page.send method, *args if args

--- a/lib/page_navigation/routes.rb
+++ b/lib/page_navigation/routes.rb
@@ -6,7 +6,7 @@ module PageNavigation
     end
     
     def routes=(routes)
-      raise("You must provide a :default route") unless routes[:default]
+      raise('You must provide a :default route') unless routes[:default]
       @routes = routes
     end
 

--- a/lib/page_navigation/version.rb
+++ b/lib/page_navigation/version.rb
@@ -1,3 +1,3 @@
 module PageNavigation
-  VERSION = "0.9"
+  VERSION = '0.11'
 end

--- a/page_navigation.gemspec
+++ b/page_navigation.gemspec
@@ -4,21 +4,21 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'page_navigation/version'
 
 Gem::Specification.new do |gem|
-  gem.name          = "page_navigation"
+  gem.name          = 'page_navigation'
   gem.version       = PageNavigation::VERSION
   gem.platform      = Gem::Platform::RUBY
-  gem.authors       = ["Jeffrey S. Morgan"]
-  gem.email         = ["jeff.morgan@leandog.com"]
-  gem.homepage      = "http://github.com/cheezy/page_navigation"
+  gem.authors       = ['Jeffrey S. Morgan','Dmitry Sharkov']
+  gem.email         = ['jeff.morgan@leandog.com']
+  gem.homepage      = 'http://github.com/cheezy/page_navigation'
   gem.description   = %q{Provides basic navigation through a collection of items that use the PageObject pattern.}
   gem.summary       = %q{Provides basic navigation through a collection of items that use the PageObject pattern.}
 
-  gem.rubyforge_project = "page_navigation"
+  gem.rubyforge_project = 'page_navigation'
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib"]
+  gem.require_paths = ['lib']
 
   gem.add_dependency 'data_magic', '>= 0.22'
   

--- a/page_navigation.gemspec
+++ b/page_navigation.gemspec
@@ -13,15 +13,14 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Provides basic navigation through a collection of items that use the PageObject pattern.}
   gem.summary       = %q{Provides basic navigation through a collection of items that use the PageObject pattern.}
 
-  gem.rubyforge_project = "page_naigation"
+  gem.rubyforge_project = "page_navigation"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'data_magic', '>= 0.14'
+  gem.add_dependency 'data_magic', '>= 0.22'
   
-  gem.add_development_dependency 'rspec', '>= 2.12.0'
-
+  gem.add_development_dependency 'rspec', '>= 3.4.0'
 end

--- a/spec/lib/page_navigation_spec.rb
+++ b/spec/lib/page_navigation_spec.rb
@@ -1,20 +1,26 @@
 require 'spec_helper'
 
-class FactoryTestPage
+class FirstPage
 end
 
-class AnotherPage
+class MiddlePage
 end
 
-class YetAnotherPage
+class LastPage
 end
 
 class TestNavigator
   include PageNavigation
   attr_accessor :current_page
 
-  def on(cls)
+  def on(cls) #placeholder for PageFactory's on_page (alias 'on')
     cls.new
+  end
+
+  def visit(cls) #placeholder for PageFactory's visit_page (alias 'visit')
+    page_instance = cls.new
+    page_instance.visit
+    page_instance
   end
 
   def class_from_string(str)
@@ -27,137 +33,178 @@ end
 describe PageNavigation do
   before(:each) do
     @navigator = TestNavigator.new
-    DataMagic.stub(:load)
+    allow(DataMagic).to receive(:load)
   end
 
-  it "should raise an error when you do not provide a default route" do
-    expect { TestNavigator.routes = {:another => []} }.to raise_error
+  it 'should raise an error when you do not provide a default route' do
+    expect { TestNavigator.routes = {:another => []} }.to raise_error 'You must provide a :default route'
   end
 
-  it "should store the routes" do
-    routes = ['a', 'b', 'c']
+  it 'should store the routes' do
+    routes = %w(a b c)
     TestNavigator.routes = {:default => routes}
-    TestNavigator.routes[:default].should == routes
+    expect(TestNavigator.routes[:default]).to be routes
   end
 
-  it "should store route data" do
+  it 'should store route data' do
     TestNavigator.route_data = {:default => :blah}
-    TestNavigator.route_data.should == {:default => :blah}
+    expect(TestNavigator.route_data).to eq ({:default => :blah})
   end
 
-  it "should navigate to a page calling the default methods" do
-    pages = [[FactoryTestPage, :a_method], [AnotherPage, :b_method]]
+  it 'should navigate to a page calling the default methods' do
+    pages = [[FirstPage, :a_method], [MiddlePage, :b_method]]
     TestNavigator.routes = {:default => pages}
-    fake_page = double('a_page')
-    FactoryTestPage.should_receive(:new).and_return(fake_page)
-    fake_page.should_receive(:a_method)
-    @navigator.navigate_to(AnotherPage).class.should == AnotherPage
+    fake_page = double('middle_page')
+    expect(FirstPage).to receive(:new).and_return(fake_page)
+    expect(fake_page).to receive(:a_method)
+    expect(@navigator.navigate_to(MiddlePage).class).to be MiddlePage
   end
 
-  it "should load the DataMagic file when specified" do
-    pages = [[FactoryTestPage, :a_method], [AnotherPage, :b_method]]
+  it 'should load the DataMagic file when specified' do
+    pages = [[FirstPage, :a_method], [MiddlePage, :b_method]]
     TestNavigator.routes = {:default => pages}
     TestNavigator.route_data = {:default => :dm_file}
-    fake_page = double('a_page')
-    FactoryTestPage.should_receive(:new).and_return(fake_page)
-    fake_page.should_receive(:a_method)
-    DataMagic.should_receive(:load).with('dm_file.yml')
-    @navigator.navigate_to(AnotherPage).class.should == AnotherPage
+    fake_page = double('middle_page')
+    expect(FirstPage).to receive(:new).and_return(fake_page)
+    expect(fake_page).to receive(:a_method)
+    expect(DataMagic).to receive(:load).with('dm_file.yml')
+    expect(@navigator.navigate_to(MiddlePage).class).to be MiddlePage
   end
 
-  it "should pass parameters to methods when navigating" do
-    pages = [[FactoryTestPage, :a_method, 'blah'], [AnotherPage, :b_method]]
+  it 'should pass parameters to methods when navigating' do
+    pages = [[FirstPage, :a_method, 'blah'], [MiddlePage, :b_method]]
     TestNavigator.routes = {:default => pages}
-    fake_page = double('a_page')
-    FactoryTestPage.should_receive(:new).and_return(fake_page)
-    fake_page.should_receive(:a_method).with('blah')
-    @navigator.navigate_to(AnotherPage).class.should == AnotherPage
+    fake_page = double('middle_page')
+    expect(FirstPage).to receive(:new).and_return(fake_page)
+    expect(fake_page).to receive(:a_method).with('blah')
+    expect(@navigator.navigate_to(MiddlePage).class).to be MiddlePage
   end
 
-  it "should fail when it does not find a proper route" do
+  it 'should fail when it does not find a proper route' do
     TestNavigator.routes = {:default => ['a'], :another => ['b']}
-    expect { @navigator.navigate_to(AnotherPage, :using => :no_route) }.to raise_error
+    expect { @navigator.navigate_to(MiddlePage, :using => :no_route) }.to raise_error
   end
 
-  it "should fail when no default method specified" do
+  it 'should fail when no default method specified' do
     TestNavigator.routes = {
-      :default => [[FactoryTestPage, :a_method], [AnotherPage, :b_method]]
+      :default => [[FirstPage, :a_method], [MiddlePage, :b_method]]
     }
-    fake_page = double('a_page')
-    FactoryTestPage.should_receive(:new).and_return(fake_page)
-    fake_page.should_receive(:respond_to?).with(:a_method).and_return(false)
-    expect { @navigator.navigate_to(AnotherPage) }.to raise_error
+    fake_page = double('middle_page')
+    expect(FirstPage).to receive(:new).and_return(fake_page)
+    expect(fake_page).to receive(:respond_to?).with(:a_method).and_return(false)
+    expect { @navigator.navigate_to(MiddlePage) }.to raise_error
   end
 
-  it "should know how to continue routng from a location" do
-    TestNavigator.routes = {
-      :default => [[FactoryTestPage, :a_method],
-                   [AnotherPage, :b_method],
-                   [YetAnotherPage, :c_method]]
-    }
-    @navigator.current_page = FactoryTestPage.new
-    f_page = FactoryTestPage.new
-    a_page = AnotherPage.new
-    FactoryTestPage.should_receive(:new).and_return(f_page)
-    f_page.should_receive(:respond_to?).with(:a_method).and_return(true)
-    f_page.should_receive(:a_method)
-    AnotherPage.should_receive(:new).and_return(a_page)
-    a_page.should_receive(:respond_to?).with(:b_method).and_return(true)
-    a_page.should_receive(:b_method)
-    @navigator.continue_navigation_to(YetAnotherPage).class.should == YetAnotherPage
+  it 'should know how to continue routing from a location' do
+    first_page, middle_page, last_page = mock_common_method_calls
+
+    @navigator.current_page = FirstPage.new
+    
+    expect(first_page).to receive(:a_method)
+    expect(middle_page).to receive(:b_method)
+
+    expect(@navigator.continue_navigation_to(LastPage).class).to be LastPage
   end
 
-  it "should know how to continue routng from a location that is one page from the end" do
-    TestNavigator.routes = {
-      :default => [[FactoryTestPage, :a_method],
-                   [AnotherPage, :b_method],
-                   [YetAnotherPage, :c_method]]
-    }
-    @navigator.current_page = FactoryTestPage.new
-    f_page = FactoryTestPage.new
-    FactoryTestPage.should_receive(:new).and_return(f_page)
-    f_page.should_receive(:respond_to?).with(:a_method).and_return(true)
-    f_page.should_receive(:a_method)
-    a_page = AnotherPage.new
-    AnotherPage.should_receive(:new).and_return(a_page)
-    a_page.should_receive(:respond_to?).with(:b_method).and_return(true)
-    a_page.should_receive(:b_method)
-    @navigator.continue_navigation_to(YetAnotherPage).class.should == YetAnotherPage
+  it 'should know how to continue routing from a location that is one page from the end' do
+    first_page, middle_page, last_page = mock_common_method_calls
+
+    @navigator.current_page = MiddlePage.new
+
+    expect(first_page).not_to receive(:a_method)
+    expect(middle_page).to receive(:b_method)
+
+    expect(@navigator.continue_navigation_to(LastPage).class).to be LastPage
   end
 
-  it "should know how to navigate an entire route including the last page" do
-    TestNavigator.routes = {
-      :default => [[FactoryTestPage, :a_method],
-                   [AnotherPage, :b_method],
-                   [YetAnotherPage, :c_method]]
-    }
-    f_page = FactoryTestPage.new
-    a_page = AnotherPage.new
-    y_page = YetAnotherPage.new
-    FactoryTestPage.should_receive(:new).and_return(f_page)
-    f_page.should_receive(:respond_to?).with(:a_method).and_return(true)
-    f_page.should_receive(:a_method)
-    AnotherPage.should_receive(:new).and_return(a_page)
-    a_page.should_receive(:respond_to?).with(:b_method).and_return(true)
-    a_page.should_receive(:b_method)
-    YetAnotherPage.should_receive(:new).and_return(y_page)
-    y_page.should_receive(:respond_to?).with(:c_method).and_return(true)
-    y_page.should_receive(:c_method)
+  it 'should know how to navigate an entire route including the last page' do
+    first_page, middle_page, last_page = mock_common_method_calls
+
+    expect(first_page).to receive(:a_method)
+    expect(middle_page).to receive(:b_method)
+    expect(last_page).to receive(:c_method)
+
     @navigator.navigate_all
   end
 
-  it "should be able to start in the middle of a route and proceed" do
-    TestNavigator.routes = {
-      :default => [[FactoryTestPage, :a_method],
-                   [AnotherPage, :b_method],
-                   [YetAnotherPage, :c_method]]
-    }
-    a_page = AnotherPage.new
-    y_page = YetAnotherPage.new
-    AnotherPage.should_receive(:new).and_return(a_page)
-    a_page.should_receive(:respond_to?).with(:b_method).and_return(true)
-    a_page.should_receive(:b_method)
-    YetAnotherPage.should_receive(:new).and_return(y_page)
-    @navigator.navigate_to(YetAnotherPage, :from => AnotherPage)
+  it 'should be able to start in the middle of a route and proceed' do
+    first_page, middle_page, last_page = mock_common_method_calls
+
+    expect(first_page).not_to receive(:a_method)
+    expect(middle_page).to receive(:b_method)
+
+    @navigator.navigate_to(LastPage, :from => MiddlePage)
   end
+
+  it 'should visit page at start of route given visit param set to true' do
+    first_page, middle_page, last_page = mock_common_method_calls
+
+    expect(first_page).to receive(:visit)
+    expect(first_page).to receive(:a_method)
+    expect(middle_page).to receive(:b_method)
+    expect(middle_page).not_to receive(:visit)
+
+    @navigator.navigate_to(LastPage, visit: true)
+  end
+
+  it 'should not visit page at start of route given visit param set to false (explicit)' do
+    first_page, middle_page, last_page = mock_common_method_calls
+
+    expect(first_page).not_to receive(:visit)
+    expect(first_page).to receive(:a_method)
+    expect(middle_page).to receive(:b_method)
+
+    @navigator.navigate_to(LastPage, visit: false)
+  end
+
+  it 'should not visit page at start of route given visit param set to false (default)' do
+    first_page, middle_page, last_page = mock_common_method_calls
+
+    expect(first_page).not_to receive(:visit)
+    expect(first_page).to receive(:a_method)
+    expect(middle_page).to receive(:b_method)
+
+    @navigator.navigate_to(LastPage)
+  end
+
+  it 'should handle specification of both using and visit params' do
+    first_page, middle_page, last_page = mock_common_method_calls
+
+    expect(first_page).to receive(:respond_to?).with(:x_method).at_least(:once).and_return(true)
+    expect(first_page).to receive(:visit)
+    expect(first_page).to receive(:x_method)
+    expect(middle_page).to receive(:respond_to?).with(:y_method).at_least(:once).and_return(true)
+    expect(middle_page).to receive(:y_method)
+    expect(middle_page).not_to receive(:visit)
+
+    @navigator.navigate_to(LastPage, visit: true, using: :alt)
+  end
+end
+
+def mock_common_method_calls
+  TestNavigator.routes = {
+      :default => [[FirstPage, :a_method],
+                   [MiddlePage, :b_method],
+                   [LastPage, :c_method]],
+      :alt => [[FirstPage, :x_method],
+               [MiddlePage, :y_method],
+               [LastPage, :z_method]]
+  }
+
+  first_page = FirstPage.new
+  allow(FirstPage).to receive(:new).and_return(first_page)
+  allow(first_page).to receive(:respond_to?).with(:visit).and_return(true)
+  allow(first_page).to receive(:respond_to?).with(:a_method).and_return(true)
+
+  middle_page = MiddlePage.new
+  allow(MiddlePage).to receive(:new).and_return(middle_page)
+  allow(middle_page).to receive(:respond_to?).with(:visit).and_return(true)
+  allow(middle_page).to receive(:respond_to?).with(:b_method).and_return(true)
+
+  last_page = LastPage.new
+  allow(LastPage).to receive(:new).and_return(last_page)
+  allow(last_page).to receive(:respond_to?).with(:visit).and_return(true)
+  allow(last_page).to receive(:respond_to?).with(:c_method).and_return(true)
+
+  return first_page, middle_page, last_page
 end


### PR DESCRIPTION
Added ability to specify whether to begin the navigation with a "visit_page" as opposed to "on_page." This is to eliminate the need to always start a navigation flow with "visit(FirstPage)." Now you can optionally do "navigate_to(LastPage, :using => :my_route, :visit => true)". Refactored specs to eliminate copy-paste, added new ones, made sure everything was passing. Built and installed locally to test out in a current test suite, so far so good.